### PR TITLE
Add notes about libstd-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ See [zstd library](https://github.com/facebook/zstd).
 
 Please install zstd library first, use latest 1.4.0+ version.
 
+Also some server installations (especially CentOS) might require [libzstd-devel](https://pkgs.org/download/libzstd-devel) package installation.
+
 ```sh
 gem install ruby-zstds
 ```


### PR DESCRIPTION
We stuck with issue that gem wasn't able to compile native extensions without that lib on Amazon Linux 2, so, it would be nice to have in Readme, I think. 