### PR TITLE
Make `rake compile` work on M1 Macs and add install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ gem install pkg/ruby-zstds-*.gem
 
 You can also use [overlay](https://github.com/andrew-aladev/overlay) for gentoo.
 
+### Installing in macOS on Apple Silicon
+On M1 Macs, Homebrew installs to /opt/homebrew, so you'll need to specify its
+include and lib paths when building the native extension for zstd.
+
+```sh
+brew install zstd
+gem install ruby-zstds -- --with-opt-include=/opt/homebrew/include --with-opt-lib=/opt/homebrew/lib
+```
+
+You can also configure Bundler to use those options when installing:
+
+```sh
+bundle config set build.ruby-zstds "--with-opt-include=/opt/homebrew/include --with-opt-lib=/opt/homebrew/lib"
+```
+
 ## Usage
 
 There are simple APIs: `String` and `File`. Also you can use generic streaming API: `Stream::Writer` and `Stream::Reader`.

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,11 @@ Rake::ExtensionTask.new do |ext|
   ext.lib_dir        = "lib"
   ext.tmp_dir        = "tmp"
   ext.source_pattern = "*.{c,h}"
+
+  if File.directory?("/opt/homebrew")
+    ext.config_options << "--with-opt-include=/opt/homebrew/include"
+    ext.config_options << "--with-opt-lib=/opt/homebrew/lib"
+  end
 end
 
 Rake::TestTask.new do |task|


### PR DESCRIPTION
This change includes the new `/opt/homebrew` prefix in the load paths and adds README instructions on how to configure Bundler to build with the correct paths.