### PR TITLE
Add option for disabling IO object validation in stream classes

### DIFF
--- a/lib/zstds/stream/abstract.rb
+++ b/lib/zstds/stream/abstract.rb
@@ -25,7 +25,10 @@ module ZSTDS
       def initialize(io, options = {})
         @raw_stream = create_raw_stream
 
-        Validation.validate_io io
+        if options.fetch(:validate, true)
+          Validation.validate_io io
+        end
+
         @io = io
 
         @stat = Stat.new @io.stat if @io.respond_to? :stat

--- a/lib/zstds/stream/reader.rb
+++ b/lib/zstds/stream/reader.rb
@@ -16,7 +16,7 @@ module ZSTDS
       def initialize(source_io, options = {}, *args)
         @options = options
 
-        super source_io, *args
+        super source_io, options, *args
 
         initialize_source_buffer_length
         reset_io_remainder

--- a/lib/zstds/stream/writer.rb
+++ b/lib/zstds/stream/writer.rb
@@ -13,7 +13,7 @@ module ZSTDS
       def initialize(destination_io, options = {}, *args)
         @options = options
 
-        super destination_io, *args
+        super destination_io, options, *args
       end
 
       protected def create_raw_stream


### PR DESCRIPTION
This allows streaming to IO-like objects that don't respond to all of the methods checked for in `Validation.validate_io` such as the `ActionController::Live` streaming response object in Rails.